### PR TITLE
exluded github and google url list

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,6 +12,10 @@
     "content_scripts": [
         {
             "matches": ["<all_urls>"],
+            "exclude_matches": [
+                "*://www.google.com/*",
+                "*://github.com/*"
+            ],
             "js": ["script.js"]
         }
     ]


### PR DESCRIPTION
```
            "exclude_matches": [
                "*://www.google.com/*",
                "*://github.com/*"
            ],
```
Here, exclude_matches prevents script.js from being injected into these urls.

@KendallDoesCoding Could you this and let me if there is anyone wrong or not right??